### PR TITLE
Adaptive Android Studio Bumblebee | 2021.1.1 Patch 2

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -58,6 +58,8 @@
         ]]>
     </change-notes>
 
+    <depends>com.intellij.modules.java</depends>
+    
     <idea-version since-build="173.0"/>
 
     <actions>


### PR DESCRIPTION
Android Studio Bumblebee | 2021.1.1 Patch 2 can't install this plugin,show "Compatible with Intellij IDEA only",
add `<depends>com.intellij.modules.java</depends>` in plugin.xml fix it